### PR TITLE
Correct nav path for news case study

### DIFF
--- a/app/2.0/nav.yaml
+++ b/app/2.0/nav.yaml
@@ -164,7 +164,7 @@
     path: /2.0/toolbox/case-study
     indent: True
   - title: "News"
-    path: /1.0/toolbox/news-case-study
+    path: /2.0/toolbox/news-case-study
     indent: True
   - endheader: true
 


### PR DESCRIPTION
Nav on Polymer App Toolbox page is linking to v1.0 news case study page instead of the v2.0 version.

See here:
https://www.polymer-project.org/2.0/toolbox/index